### PR TITLE
Support cbgen>=1.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ psutil>=5.6.7
 pandas>=1.1.1
 h5py>=2.10.0
 dill>=0.2.9
-cbgen==1.0.1
+cbgen>=1.0.1
 bgen-reader>=4.0.7
 wheel>=0.34.2
 bed-reader>=0.2.5


### PR DESCRIPTION
Would it be possible to support newer version of cbgen, e.g. 1.0.2 ? I had issues with installing cbgen==1.0.1, but installing 1.0.2 wasn't a problem.